### PR TITLE
Allow to prevent shortcuts processing in onKeyDown by returning false

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,8 +81,9 @@ export default React.forwardRef<HTMLTextAreaElement, TextareaCodeEditorProps>((p
         {...other}
         placeholder={placeholder}
         onKeyDown={(evn) => {
-          shortcuts(evn);
-          other.onKeyDown && other.onKeyDown(evn);
+          if (!other.onKeyDown || other.onKeyDown(evn)!==false) {
+            shortcuts(evn);
+          }
         }}
         style={{
           ...styles.editor,


### PR DESCRIPTION
Hi!

I need the functionality to "submit" the code when the user presses cmd+enter on Mac or ctrl+enter on Windows. I could "submit" in the onKeyDown but the combination would insert the enter plus indention.

Now the user can return false from onKeyDown to prevent the shortcut processing.

Sorry if the format of this pull request is wrong, it's one of my first ever :)