### PR TITLE
Updated default style for light mode

### DIFF
--- a/src/style/index.less
+++ b/src/style/index.less
@@ -18,7 +18,7 @@
 @media (prefers-color-scheme: light) {
   .@{w-textarea} {
     --color-fg-default: #24292f;
-    --color-canvas-subtle: #161b22;
+    --color-canvas-subtle: #f6f8fa;
     --color-prettylights-syntax-comment: #6e7781;
     --color-prettylights-syntax-entity-tag: #116329;
     --color-prettylights-syntax-entity: #8250df;


### PR DESCRIPTION
Styles shouldn't be different between the `prefers-color-scheme` and the explicitly declared theme. Made it consistent.